### PR TITLE
add a custom `none` role that is excluded from the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,10 @@ This extension adds custom roles that can be used in rST.
 Currently implemented:
 
 - `spellexception` - Includes the provided text in `<spellexception></spellexception>`, which makes it possible to exclude it from a spelling checker.
-- `monoref` - Renders the provided reference in code-style, which excludes the link text from the spelling checker.
-   You can provide either just the link (for example, ``:monoref:`www.example.com` ``, which results in `www.example.com` as the link text and `https://www.example.com` as the link URL) or a separate link text and URL (for example, ``:monoref:`xyzcommand <www.example.com>` ``).
+- `literalref` - Renders the provided reference in code-style, which excludes the link text from the spelling checker.
+   You can provide either just the link (for example, ``:literalref:`www.example.com` ``, which results in `www.example.com` as the link text and `https://www.example.com` as the link URL) or a separate link text and URL (for example, ``:literalref:`xyzcommand <www.example.com>` ``).
+- `none` - Excludes the provided text from the output.
+  This is useful for comments, especially when providing `wokeignore` rules.
 
 ### Config options
 

--- a/canonical-sphinx-extensions/custom-rst-roles/__init__.py
+++ b/canonical-sphinx-extensions/custom-rst-roles/__init__.py
@@ -11,6 +11,12 @@ def spellexception_role(
     return [node], []
 
 
+def none_role(
+    name, rawtext, text, lineno, inliner, options=None, content=None
+):
+    return [], []
+
+
 def literalref_role(
     name, rawtext, text, lineno, inliner, options=None, content=None
 ):
@@ -37,5 +43,6 @@ def literalref_role(
 def setup(app):
     app.add_role("spellexception", spellexception_role)
     app.add_role("literalref", literalref_role)
+    app.add_role("none", none_role)
 
     return

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canonical-sphinx-extensions
-version = 0.0.17
+version = 0.0.18
 author = Ruth Fuchss
 author_email = ruth.fuchss@canonical.com
 description = A collection of Sphinx extensions used by Canonical documentation


### PR DESCRIPTION
To ignore woke exceptions, you must provide a comment (see https://docs.getwoke.tech/ignore/#in-line-and-next-line-ignoring ). However, RST doesn't really have a concept of comments, and the workaround that is commonly used for comments requires empty lines, which again doesn't work for wokeignore.

The `:none:` role makes it possible to specify the wokeignore comment in the input file, but exclude it from the output.