### PR TITLE
Updates to the config option extension

### DIFF
--- a/canonical-sphinx-extensions/config-options/__init__.py
+++ b/canonical-sphinx-extensions/config-options/__init__.py
@@ -226,6 +226,12 @@ class ConfigDomain(Domain):
             (key, key, "option", self.env.docname, scope + ":" + key, 0)
         )
 
+    def merge_domaindata(self, docnames, otherdata):
+
+        for option in otherdata["config_options"]:
+            if option not in self.data["config_options"]:
+                self.data["config_options"].append(option)
+
 
 def setup(app):
     app.add_domain(ConfigDomain)

--- a/canonical-sphinx-extensions/config-options/__init__.py
+++ b/canonical-sphinx-extensions/config-options/__init__.py
@@ -156,13 +156,40 @@ class ConfigIndex(Index):
 
         options = self.domain.get_objects()
         # sort by key name
-        options = sorted(options, key=lambda option: option[0])
+        options = sorted(options, key=lambda option: (option[1], option[4]))
+
+        dispnames = []
+        duplicates = []
+        for _name, dispname, _typ, _docname, anchor, _priority in options:
+            fullname = anchor.partition(":")[0].partition("-")[0] \
+                       + "-" + dispname
+            if fullname in dispnames:
+                duplicates.append(fullname)
+            else:
+                dispnames.append(fullname)
 
         for _name, dispname, typ, docname, anchor, _priority in options:
+
+            scope = anchor.partition(":")[0].partition("-")
+
+            # if the key exists more than once within the scope, add
+            # the title of the document as extra context
+            if scope[0] + "-" + dispname in duplicates:
+                extra = str(self.domain.env.titles[docname])
+                # need some tweaking to work with our CSS
+                extra = extra.replace("<title>", "")
+                extra = extra.replace("</title>", "")
+                extra = extra.replace("<literal>", '<code class="literal">')
+                extra = extra.replace("</literal>", "</code>")
+                # add the anchor for full information
+                extra += ': <code class="literal">' + scope[2] + "</code>"
+            else:
+                extra = ""
+
             # group by the first part of the scope
             # ("XXX" if the scope is "XXX-YYY")
-            content[anchor.partition(":")[0].partition("-")[0]].append(
-                (dispname, 0, docname, anchor, "", "", "")
+            content[scope[0]].append(
+                (dispname, 0, docname, anchor, extra, "", "")
             )
 
         content = sorted(content.items())

--- a/canonical-sphinx-extensions/custom-rst-roles/__init__.py
+++ b/canonical-sphinx-extensions/custom-rst-roles/__init__.py
@@ -45,4 +45,5 @@ def setup(app):
     app.add_role("literalref", literalref_role)
     app.add_role("none", none_role)
 
-    return
+    return {"parallel_read_safe": True,
+            "parallel_write_safe": True}

--- a/canonical-sphinx-extensions/filtered-toc/__init__.py
+++ b/canonical-sphinx-extensions/filtered-toc/__init__.py
@@ -5,7 +5,9 @@ from sphinx.directives.other import TocTree
 def setup(app):
     app.add_config_value("toc_filter_exclude", [], "html")
     app.add_directive("filtered-toctree", FilteredTocTree)
-    return {"version": "1.0.0"}
+    return {"version": "1.0.0",
+            "parallel_read_safe": True,
+            "parallel_write_safe": True}
 
 
 class FilteredTocTree(TocTree):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canonical-sphinx-extensions
-version = 0.0.18
+version = 0.0.19
 author = Ruth Fuchss
 author_email = ruth.fuchss@canonical.com
 description = A collection of Sphinx extensions used by Canonical documentation


### PR DESCRIPTION
This PR combines two separate updates:

- Add some context to the output of the configuration option index
- Make all extensions (mainly the config option one) safe for parallel processing

One PR because we want to test and publish both updates.