### PR TITLE
config-options: fix JavaScript selector

### DIFF
--- a/canonical-sphinx-extensions/config-options/_static/config-options.js
+++ b/canonical-sphinx-extensions/config-options/_static/config-options.js
@@ -8,7 +8,8 @@ $(document).ready(function() {
     };
 
     /* Add icons to expand/collapse all options for one section */
-    $('.configoption:first-of-type').before("<div class=\"expand-collapse\"><span class=\"expand-all\" title=\"Expand all\">⤋</span><span class=\"collapse-all\" title=\"Collapse all\">⤊</span></div>");
+    $('.configoption').before("<div class=\"expand-collapse\"><span class=\"expand-all\" title=\"Expand all\">⤋</span><span class=\"collapse-all\" title=\"Collapse all\">⤊</span></div>");
+    $('.configoption ~ .configoption').prev(".expand-collapse").remove();
 
     /* Make the option lines expandable */
     $('.configoption div.basicinfo').click(function() {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canonical-sphinx-extensions
-version = 0.0.19
+version = 0.0.20
 author = Ruth Fuchss
 author_email = ruth.fuchss@canonical.com
 description = A collection of Sphinx extensions used by Canonical documentation


### PR DESCRIPTION
The "expand all" button wasn't always displayed correctly. This is because the "first-of-type" selector isn't meant to distinguish between classes (only types).
So instead of using "first-of-type", select all elements with the ".configoption" class and then undo the addition of the "expand all" button for all elements that are preceded by another ".configoption" element.

Fixes #35