### PR TITLE
feat(contributor-listing): list co-authors too

### DIFF
--- a/canonical-sphinx-extensions/contributor-listing/__init__.py
+++ b/canonical-sphinx-extensions/contributor-listing/__init__.py
@@ -63,16 +63,19 @@ def setup_func(app, pagename, templatename, context, doctree):
 
             contributors_dict = {}
             for commit in commits:
-                contributor = commit.author.name
-                if (
-                    contributor not in contributors_dict
-                    or commit.committed_date >
-                        contributors_dict[contributor]["date"]
-                ):
-                    contributors_dict[contributor] = {
-                        "date": commit.committed_date,
-                        "sha": commit.hexsha,
-                    }
+                contributors = [commit.author.name]
+                for co_author in commit.co_authors:
+                    contributors.append(co_author.name)
+                for contributor in contributors:
+                    if (
+                        contributor not in contributors_dict
+                        or commit.committed_date >
+                            contributors_dict[contributor]["date"]
+                    ):
+                        contributors_dict[contributor] = {
+                            "date": commit.committed_date,
+                            "sha": commit.hexsha,
+                        }
             # github_page contains the link to the contributor's latest commit
             contributors_list = [
                 (name, f"{context['github_url']}/commit/{data['sha']}")


### PR DESCRIPTION
Add co-authors as contributors in addition to the commit author. The co-authors are described in the commit message in the following format:

    Co-authored-by: name.. <email..>

Details on co-authors:
https://gitpython.readthedocs.io/en/stable/reference.html#git.objects.commit.Commit.co_authors