### PR TITLE
Omit user and host (and `@:` symbols) if they are not supplied.

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,7 +21,7 @@ jobs:
         --outdir dist/
         .
     - name: Store the package
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package
         path: dist/
@@ -37,7 +37,7 @@ jobs:
       id-token: write
     steps:
     - name: Download package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package
         path: dist/

--- a/canonical-sphinx-extensions/terminal-output/__init__.py
+++ b/canonical-sphinx-extensions/terminal-output/__init__.py
@@ -34,14 +34,23 @@ class TerminalOutput(Directive):
         return inpline
 
     def run(self):
-
         # Build prompt with :user:, :host: and :dir: (whichever is provided)
-
-        command = self.options["input"] if "input" in self.options else ""
-        user = self.options["user"] if "user" in self.options else "user"
-        host = self.options["host"] if "host" in self.options else "host"
+        user = self.options.get("user")
+        host = self.options.get("host")
         dir = self.options["dir"] if "dir" in self.options else "~"
-        prompt_text = f"{user}@{host}:{dir}{'#' if user == 'root' else '$'} "
+        command = self.options["input"] if "input" in self.options else ""
+
+        user_symbol = '#' if user == "root" else '$'
+
+        if user and host:
+            prompt_text = f"{user}@{host}:{dir}{user_symbol} "
+        elif user and not host:
+            # Only the user is supplied
+            prompt_text = f"{user}:{dir}{user_symbol} "
+        else:
+            # Omit both user and host, just showing the host
+            # doesn't really make sense
+            prompt_text = f"{dir}{user_symbol} "
 
         out = nodes.container()
         out["classes"].append("terminal")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canonical-sphinx-extensions
-version = 0.0.24
+version = 0.0.25
 author = Ruth Fuchss
 author_email = ruth.fuchss@canonical.com
 description = A collection of Sphinx extensions used by Canonical documentation


### PR DESCRIPTION
Resolves #49 
In a better way than #50 did.