### PR TITLE
Add the :empty: parameter

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canonical-sphinx-extensions
-version = 0.0.26
+version = 0.0.27
 author = Ruth Fuchss
 author_email = ruth.fuchss@canonical.com
 description = A collection of Sphinx extensions used by Canonical documentation


### PR DESCRIPTION
Requested on the [original docs](https://github.com/canonical/ubuntu-boards-documentation/commit/058d975fb1bc1c06366d0f160582e00ad124b9dc) to permit list generation for future releases.