### PR TITLE
feat: terminal command copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ Note: This supports `:input` as part of the initial configuration block. but req
 ```
 ````
 
+Note: This extension overrides the default `copybutton_selector` used by [sphinx-copybutton](https://sphinx-copybutton.readthedocs.io/en/latest/index.html). Add the `no-copybutton` class to code-blocks or terminal directives to disable the copy button. 
+
 ### Filtered ToC
 
 This extension adds a `:filtered-toctree:` directive that is almost the same as the normal `:toctree:` directive but allows excluding pages based on specified filters.

--- a/canonical-sphinx-extensions/terminal-output/__init__.py
+++ b/canonical-sphinx-extensions/terminal-output/__init__.py
@@ -3,7 +3,9 @@ from sphinx.util.docutils import SphinxDirective
 from docutils.parsers.rst import directives
 from . import common
 import sphinx
+from sphinx.application import Sphinx
 
+copybutton_classes = "div.terminal:not(.no-copybutton) > div.container > code.command, div:not(.terminal-code, .no-copybutton) > div.highlight > pre"
 
 def parse_contents(contents):
     command_output = []
@@ -27,6 +29,7 @@ class TerminalOutput(SphinxDirective):
     optional_arguments = 0
     has_content = True
     option_spec = {
+        "class": directives.class_option,
         "input": directives.unchanged,
         "user": directives.unchanged,
         "host": directives.unchanged,
@@ -58,6 +61,7 @@ class TerminalOutput(SphinxDirective):
     def run(self):
         # if :user: or :host: are provided, replace those in the prompt
 
+        classes = self.options.get("class", "")
         command = self.options.get("input", "")
         user = self.options.get("user", "user")
         host = self.options.get("host", "host")
@@ -75,6 +79,8 @@ class TerminalOutput(SphinxDirective):
 
         out = nodes.container()
         out["classes"].append("terminal")
+        for item in classes:
+            out["classes"].append(item)
         # The super-large value for linenothreshold is a major hack since I
         # can't figure out how to disable line numbering and the
         # linenothreshold kwarg seems to be required.
@@ -107,9 +113,10 @@ class TerminalOutput(SphinxDirective):
         return [out]
 
 
-def setup(app):
+def setup(app: Sphinx):
     app.add_directive("terminal", TerminalOutput)
 
     common.add_css(app, "terminal-output.css")
+    app.config.copybutton_selector = copybutton_classes
 
     return {"version": "0.1", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/canonical-sphinx-extensions/terminal-output/_static/terminal-output.css
+++ b/canonical-sphinx-extensions/terminal-output/_static/terminal-output.css
@@ -37,3 +37,38 @@
 div.terminal-code {
     margin: 0 0;
 }
+
+/* Copybutton settings */
+
+div.input  {
+    position: relative;
+}
+
+div.input > button.copybtn {
+    overflow-y: visible;
+    top: 0.1em;
+    right: 0.1em;
+    width: 1.4em;
+    height: 1.4em;
+}
+
+div.input > button.copybtn svg {
+    width: 1.2em;
+    height: 1.2em;
+}
+
+.input:hover button.copybtn, button.copybtn.success {
+	opacity: 1;
+}
+
+.input button.copybtn:hover {
+    background-color: rgb(235, 235, 235);
+}
+
+.input button.copybtn:active {
+    background-color: rgb(187, 187, 187);
+}
+
+.terminal.scroll > .input {
+    width: inherit;
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canonical-sphinx-extensions
-version = 0.0.31
+version = 0.0.32
 author = Michael Park
 author_email = michael.park@canonical.com
 description = A collection of Sphinx extensions used by Canonical documentation


### PR DESCRIPTION
* Adds CSS required to display the copybutton on specific `div`s.
* Sets `copybutton_selector` to function on command input, and disable it on terminal output.
* Sets `copybutton_selector` to ignore code blocks and terminal directives with the `no-copybutton` class.
* Adds minimal documentation.
* Prevents setting the `copybutton_selector` locally. Note: need to fix this eventually - need to load and parse the config the same way `canonical-sphinx` does to set a default that can be overwritten.