### PR TITLE
fix: make terminal output visible in light mode

### DIFF
--- a/canonical-sphinx-extensions/terminal-output/_static/terminal-output.css
+++ b/canonical-sphinx-extensions/terminal-output/_static/terminal-output.css
@@ -7,6 +7,7 @@
 
 .terminal .highlight {
     background-color: #202020;
+    color: #ebebeb;
 }
 
 .terminal .output {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canonical-sphinx-extensions
-version = 0.0.32
+version = 0.0.33
 author = Michael Park
 author_email = michael.park@canonical.com
 description = A collection of Sphinx extensions used by Canonical documentation


### PR DESCRIPTION
Fixes #72.

This PR updates terminal-output.css to make the colours in `.terminal .highlight` match the colours in `.terminal`. From my memory of such things, `color` and `background-color` should always be specified together.