### PR TITLE
fix: make spacing & sizing of related links consistent with the contents

### DIFF
--- a/canonical-sphinx-extensions/related-links/_static/related-links.css
+++ b/canonical-sphinx-extensions/related-links/_static/related-links.css
@@ -8,7 +8,7 @@
 }
 
 .relatedlinks {
-    font-size: var(--font-size--small--2);
+    font-size: var(--toc-font-size);
     line-height: 1.3;
     padding-left: calc(var(--toc-spacing-horizontal) - var(--toc-item-spacing-horizontal));
     padding-bottom: 1em;

--- a/canonical-sphinx-extensions/related-links/_static/related-links.css
+++ b/canonical-sphinx-extensions/related-links/_static/related-links.css
@@ -9,6 +9,7 @@
 
 .relatedlinks {
     font-size: var(--font-size--small--2);
+    line-height: 1.3;
     padding-left: calc(var(--toc-spacing-horizontal) - var(--toc-item-spacing-horizontal));
     padding-bottom: 1em;
 }

--- a/canonical-sphinx-extensions/related-links/_static/related-links.css
+++ b/canonical-sphinx-extensions/related-links/_static/related-links.css
@@ -35,5 +35,6 @@
 }
 
 .relatedlinks-title-container {
-    padding-top: 2em;
+    padding: var(--toc-title-padding);
+    padding-top: var(--toc-spacing-vertical);
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canonical-sphinx-extensions
-version = 0.0.33
+version = 0.0.34
 author = Michael Park
 author_email = michael.park@canonical.com
 description = A collection of Sphinx extensions used by Canonical documentation


### PR DESCRIPTION
This PR adjusts the vertical spacing around related links and increases the font size slightly. My intention is to be consistent with the appearance of the "contents" block. Debatable whether this is a "fix", but from reading the CSS it does seem like that was the original intention.

Side-by-side comparison (new version at the top):

<img width="432" src="https://github.com/user-attachments/assets/fe9e4ebb-948e-415b-9818-1b069422ea4d" />
